### PR TITLE
Mark Jetty as a testing dependency only

### DIFF
--- a/bootique/pom.xml
+++ b/bootique/pom.xml
@@ -63,6 +63,7 @@
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-servlet</artifactId>
 				<version>9.3.6.v20151106</version>
+				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Jetty server isn't actually used anywhere in this module except in tests.