### PR TITLE
Update Guice to 4.2.0 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,7 @@
 * #201 Speed up BQDaemonTestFactory
 * #211 BQRuntimeChecker - static helper for runtime assertions
 * #212 Rename "BQModuleProviderChecker.testPresentInJar" to "testAutoLoadable" 
+* #188 Update Guice to 4.1.0
 
 ## 0.24
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,7 +12,7 @@
 * #201 Speed up BQDaemonTestFactory
 * #211 BQRuntimeChecker - static helper for runtime assertions
 * #212 Rename "BQModuleProviderChecker.testPresentInJar" to "testAutoLoadable" 
-* #188 Update Guice to 4.1.0
+* #188 Update Guice to 4.2.0
 
 ## 0.24
 

--- a/bootique/pom.xml
+++ b/bootique/pom.xml
@@ -18,7 +18,7 @@
 	</description>
 
 	<properties>
-		<guice-version>4.1.0</guice-version>
+		<guice-version>4.2.0</guice-version>
 		<jackson-version>2.6.4</jackson-version>
 	</properties>
 
@@ -27,11 +27,6 @@
 			<dependency>
 				<groupId>com.google.inject</groupId>
 				<artifactId>guice</artifactId>
-				<version>${guice-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.inject.extensions</groupId>
-				<artifactId>guice-multibindings</artifactId>
 				<version>${guice-version}</version>
 			</dependency>
 			<dependency>
@@ -104,11 +99,6 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.google.inject.extensions</groupId>
-			<artifactId>guice-multibindings</artifactId>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/bootique/pom.xml
+++ b/bootique/pom.xml
@@ -18,7 +18,7 @@
 	</description>
 
 	<properties>
-		<guice-version>4.0</guice-version>
+		<guice-version>4.1.0</guice-version>
 		<jackson-version>2.6.4</jackson-version>
 	</properties>
 

--- a/bootique/src/main/java/io/bootique/Bootique.java
+++ b/bootique/src/main/java/io/bootique/Bootique.java
@@ -5,6 +5,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.ProvisionException;
+import com.google.inject.spi.Message;
 import io.bootique.command.CommandOutcome;
 import io.bootique.env.DefaultEnvironment;
 import io.bootique.log.BootLogger;
@@ -356,7 +357,14 @@ public class Bootique {
         catch (CreationException ce) {
             o = processExceptions(ce.getCause(), ce);
         } catch (ProvisionException pe) {
-            o = processExceptions(pe.getCause(), pe);
+            // Actually we can provide multiple exceptions here
+            // since ProvisionException save all errors in error messages
+            final Throwable cause = pe.getErrorMessages()
+                    .stream()
+                    .findFirst()
+                    .map(Message::getCause)
+                    .orElse(null);
+            o = processExceptions(cause, pe);
         } catch (Throwable th) {
             o = processExceptions(th, th);
         }


### PR DESCRIPTION
Since 4.2.0 guice catch more provisioning errors (looks like he doesn't stop on first provisioning error).
So because of it we should change implementation of `CommandOutcome exec()`, what I'm done in this PR.