### PR TITLE
Add BQModuleId to check module uniqueness

### DIFF
--- a/bootique/src/main/java/io/bootique/BQModuleId.java
+++ b/bootique/src/main/java/io/bootique/BQModuleId.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to ObjectStyle LLC under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ObjectStyle LLC licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.bootique;
+
+import java.util.Objects;
+
+import io.bootique.di.BQModule;
+
+/**
+ * An abstract {@link BQModule} identifier, generally is a thin wrapper around module {@link Class}.
+ */
+class BQModuleId {
+
+    private final Class<? extends BQModule> moduleClass;
+
+    static BQModuleId of(BQModule module) {
+        return new BQModuleId(module.getClass());
+    }
+
+    BQModuleId(Class<? extends BQModule> moduleClass) {
+        this.moduleClass = Objects.requireNonNull(moduleClass);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BQModuleId that = (BQModuleId) o;
+        return moduleClass.equals(that.moduleClass);
+    }
+
+    @Override
+    public int hashCode() {
+        return moduleClass.hashCode();
+    }
+}

--- a/bootique/src/main/java/io/bootique/BQModuleMetadata.java
+++ b/bootique/src/main/java/io/bootique/BQModuleMetadata.java
@@ -41,6 +41,7 @@ public class BQModuleMetadata {
             .build();
 
     private BQModule module;
+    private BQModuleId moduleId;
     private String name;
     private String description;
     private String providerName;
@@ -78,12 +79,28 @@ public class BQModuleMetadata {
         return configs;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BQModuleMetadata that = (BQModuleMetadata) o;
+
+        return moduleId.equals(that.moduleId);
+    }
+
+    @Override
+    public int hashCode() {
+        return moduleId.hashCode();
+    }
+
     public static class Builder {
         private BQModuleMetadata module;
 
         private Builder(BQModule module) {
             this.module = new BQModuleMetadata();
             this.module.module = Objects.requireNonNull(module);
+            this.module.moduleId = BQModuleId.of(module);
         }
 
         public BQModuleMetadata build() {

--- a/bootique/src/test/java/io/bootique/BootiqueUtilsTest.java
+++ b/bootique/src/test/java/io/bootique/BootiqueUtilsTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.internal.verification.AtLeast;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -36,7 +37,7 @@ public class BootiqueUtilsTest {
 
     @Test
     public void testToArray() {
-        assertArrayEquals(new String[]{}, BootiqueUtils.toArray(asList()));
+        assertArrayEquals(new String[]{}, BootiqueUtils.toArray(Collections.emptyList()));
         assertArrayEquals(new String[]{"a", "b", "c"}, BootiqueUtils.toArray(asList("a", "b", "c")));
     }
 
@@ -56,20 +57,35 @@ public class BootiqueUtilsTest {
 
         when(testModuleProvider1.dependencies()).thenReturn(asList(testModuleProvider2, testModuleProvider3));
 
-        Collection<BQModuleProvider> bqModuleProviders =
-                BootiqueUtils.moduleProviderDependencies(singletonList(testModuleProvider1));
+        BQModuleMetadata.Builder builder1 = mock(BQModuleMetadata.Builder.class);
+        BQModuleMetadata metadata1 = mock(BQModuleMetadata.class);
+        when(builder1.build()).thenReturn(metadata1);
+        when(testModuleProvider1.moduleBuilder()).thenReturn(builder1);
 
-        assertEquals(3, bqModuleProviders.size());
-        assertTrue(bqModuleProviders.contains(testModuleProvider1));
-        assertTrue(bqModuleProviders.contains(testModuleProvider2));
-        assertTrue(bqModuleProviders.contains(testModuleProvider3));
+        BQModuleMetadata.Builder builder2 = mock(BQModuleMetadata.Builder.class);
+        BQModuleMetadata metadata2 = mock(BQModuleMetadata.class);
+        when(builder2.build()).thenReturn(metadata2);
+        when(testModuleProvider2.moduleBuilder()).thenReturn(builder2);
+
+        BQModuleMetadata.Builder builder3 = mock(BQModuleMetadata.Builder.class);
+        BQModuleMetadata metadata3 = mock(BQModuleMetadata.class);
+        when(builder3.build()).thenReturn(metadata3);
+        when(testModuleProvider3.moduleBuilder()).thenReturn(builder3);
+
+        Collection<BQModuleMetadata> bqModuleMetadata =
+            BootiqueUtils.moduleProviderDependencies(singletonList(testModuleProvider1));
+
+        assertEquals(3, bqModuleMetadata.size());
+        assertTrue(bqModuleMetadata.contains(testModuleProvider1));
+        assertTrue(bqModuleMetadata.contains(testModuleProvider2));
+        assertTrue(bqModuleMetadata.contains(testModuleProvider3));
 
         verify(testModuleProvider1, new AtLeast(1)).dependencies();
-        verify(testModuleProvider1, new AtLeast(1)).name();
+        verify(testModuleProvider1, new AtLeast(1)).moduleBuilder();
         verify(testModuleProvider2, new AtLeast(1)).dependencies();
-        verify(testModuleProvider2, new AtLeast(1)).name();
+        verify(testModuleProvider2, new AtLeast(1)).moduleBuilder();
         verify(testModuleProvider3, new AtLeast(1)).dependencies();
-        verify(testModuleProvider3, new AtLeast(1)).name();
+        verify(testModuleProvider3, new AtLeast(1)).moduleBuilder();
 
         verifyNoMoreInteractions(testModuleProvider1, testModuleProvider2, testModuleProvider3);
     }
@@ -80,23 +96,37 @@ public class BootiqueUtilsTest {
         BQModuleProvider testModuleProvider2 = mock(BQModuleProvider.class);
         BQModuleProvider testModuleProvider3 = mock(BQModuleProvider.class);
 
-        when(testModuleProvider1.dependencies()).thenReturn(singletonList(testModuleProvider2));
-        when(testModuleProvider2.dependencies()).thenReturn(singletonList(testModuleProvider3));
+        when(testModuleProvider1.dependencies()).thenReturn(asList(testModuleProvider2, testModuleProvider3));
 
-        Collection<BQModuleProvider> bqModuleProviders =
+        BQModuleMetadata.Builder builder1 = mock(BQModuleMetadata.Builder.class);
+        BQModuleMetadata metadata1 = mock(BQModuleMetadata.class);
+        when(builder1.build()).thenReturn(metadata1);
+        when(testModuleProvider1.moduleBuilder()).thenReturn(builder1);
+
+        BQModuleMetadata.Builder builder2 = mock(BQModuleMetadata.Builder.class);
+        BQModuleMetadata metadata2 = mock(BQModuleMetadata.class);
+        when(builder2.build()).thenReturn(metadata2);
+        when(testModuleProvider2.moduleBuilder()).thenReturn(builder2);
+
+        BQModuleMetadata.Builder builder3 = mock(BQModuleMetadata.Builder.class);
+        BQModuleMetadata metadata3 = mock(BQModuleMetadata.class);
+        when(builder3.build()).thenReturn(metadata3);
+        when(testModuleProvider3.moduleBuilder()).thenReturn(builder3);
+
+        Collection<BQModuleMetadata> bqModuleMetadata =
                 BootiqueUtils.moduleProviderDependencies(singletonList(testModuleProvider1));
 
-        assertEquals(3, bqModuleProviders.size());
-        assertTrue(bqModuleProviders.contains(testModuleProvider1));
-        assertTrue(bqModuleProviders.contains(testModuleProvider2));
-        assertTrue(bqModuleProviders.contains(testModuleProvider3));
+        assertEquals(3, bqModuleMetadata.size());
+        assertTrue(bqModuleMetadata.contains(testModuleProvider1));
+        assertTrue(bqModuleMetadata.contains(testModuleProvider2));
+        assertTrue(bqModuleMetadata.contains(testModuleProvider3));
 
         verify(testModuleProvider1, new AtLeast(1)).dependencies();
-        verify(testModuleProvider1, new AtLeast(1)).name();
+        verify(testModuleProvider1, new AtLeast(1)).moduleBuilder();
         verify(testModuleProvider2, new AtLeast(1)).dependencies();
-        verify(testModuleProvider2, new AtLeast(1)).name();
+        verify(testModuleProvider2, new AtLeast(1)).moduleBuilder();
         verify(testModuleProvider3, new AtLeast(1)).dependencies();
-        verify(testModuleProvider3, new AtLeast(1)).name();
+        verify(testModuleProvider3, new AtLeast(1)).moduleBuilder();
 
         verifyNoMoreInteractions(testModuleProvider1, testModuleProvider2, testModuleProvider3);
     }
@@ -107,24 +137,37 @@ public class BootiqueUtilsTest {
         BQModuleProvider testModuleProvider2 = mock(BQModuleProvider.class);
         BQModuleProvider testModuleProvider3 = mock(BQModuleProvider.class);
 
-        when(testModuleProvider1.dependencies()).thenReturn(singletonList(testModuleProvider2));
-        when(testModuleProvider2.dependencies()).thenReturn(singletonList(testModuleProvider3));
-        when(testModuleProvider3.dependencies()).thenReturn(singletonList(testModuleProvider1));
+        when(testModuleProvider1.dependencies()).thenReturn(asList(testModuleProvider2, testModuleProvider3));
 
-        Collection<BQModuleProvider> bqModuleProviders =
+        BQModuleMetadata.Builder builder1 = mock(BQModuleMetadata.Builder.class);
+        BQModuleMetadata metadata1 = mock(BQModuleMetadata.class);
+        when(builder1.build()).thenReturn(metadata1);
+        when(testModuleProvider1.moduleBuilder()).thenReturn(builder1);
+
+        BQModuleMetadata.Builder builder2 = mock(BQModuleMetadata.Builder.class);
+        BQModuleMetadata metadata2 = mock(BQModuleMetadata.class);
+        when(builder2.build()).thenReturn(metadata2);
+        when(testModuleProvider2.moduleBuilder()).thenReturn(builder2);
+
+        BQModuleMetadata.Builder builder3 = mock(BQModuleMetadata.Builder.class);
+        BQModuleMetadata metadata3 = mock(BQModuleMetadata.class);
+        when(builder3.build()).thenReturn(metadata3);
+        when(testModuleProvider3.moduleBuilder()).thenReturn(builder3);
+
+        Collection<BQModuleMetadata> bqModuleMetadata =
                 BootiqueUtils.moduleProviderDependencies(singletonList(testModuleProvider1));
 
-        assertEquals(3, bqModuleProviders.size());
-        assertTrue(bqModuleProviders.contains(testModuleProvider1));
-        assertTrue(bqModuleProviders.contains(testModuleProvider2));
-        assertTrue(bqModuleProviders.contains(testModuleProvider3));
+        assertEquals(3, bqModuleMetadata.size());
+        assertTrue(bqModuleMetadata.contains(testModuleProvider1));
+        assertTrue(bqModuleMetadata.contains(testModuleProvider2));
+        assertTrue(bqModuleMetadata.contains(testModuleProvider3));
 
         verify(testModuleProvider1, new AtLeast(1)).dependencies();
-        verify(testModuleProvider1, new AtLeast(1)).name();
+        verify(testModuleProvider1, new AtLeast(1)).moduleBuilder();
         verify(testModuleProvider2, new AtLeast(1)).dependencies();
-        verify(testModuleProvider2, new AtLeast(1)).name();
+        verify(testModuleProvider2, new AtLeast(1)).moduleBuilder();
         verify(testModuleProvider3, new AtLeast(1)).dependencies();
-        verify(testModuleProvider3, new AtLeast(1)).name();
+        verify(testModuleProvider3, new AtLeast(1)).moduleBuilder();
 
         verifyNoMoreInteractions(testModuleProvider1, testModuleProvider2, testModuleProvider3);
     }

--- a/bootique/src/test/java/io/bootique/BootiqueUtilsTest.java
+++ b/bootique/src/test/java/io/bootique/BootiqueUtilsTest.java
@@ -20,7 +20,6 @@
 package io.bootique;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.internal.verification.AtLeast;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -28,10 +27,7 @@ import java.util.Collections;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class BootiqueUtilsTest {
 
@@ -76,16 +72,16 @@ public class BootiqueUtilsTest {
             BootiqueUtils.moduleProviderDependencies(singletonList(testModuleProvider1));
 
         assertEquals(3, bqModuleMetadata.size());
-        assertTrue(bqModuleMetadata.contains(testModuleProvider1));
-        assertTrue(bqModuleMetadata.contains(testModuleProvider2));
-        assertTrue(bqModuleMetadata.contains(testModuleProvider3));
+        assertTrue(bqModuleMetadata.contains(metadata1));
+        assertTrue(bqModuleMetadata.contains(metadata2));
+        assertTrue(bqModuleMetadata.contains(metadata3));
 
-        verify(testModuleProvider1, new AtLeast(1)).dependencies();
-        verify(testModuleProvider1, new AtLeast(1)).moduleBuilder();
-        verify(testModuleProvider2, new AtLeast(1)).dependencies();
-        verify(testModuleProvider2, new AtLeast(1)).moduleBuilder();
-        verify(testModuleProvider3, new AtLeast(1)).dependencies();
-        verify(testModuleProvider3, new AtLeast(1)).moduleBuilder();
+        verify(testModuleProvider1, times(1)).dependencies();
+        verify(testModuleProvider1, times(1)).moduleBuilder();
+        verify(testModuleProvider2, times(1)).dependencies();
+        verify(testModuleProvider2, times(1)).moduleBuilder();
+        verify(testModuleProvider3, times(1)).dependencies();
+        verify(testModuleProvider3, times(1)).moduleBuilder();
 
         verifyNoMoreInteractions(testModuleProvider1, testModuleProvider2, testModuleProvider3);
     }
@@ -117,16 +113,16 @@ public class BootiqueUtilsTest {
                 BootiqueUtils.moduleProviderDependencies(singletonList(testModuleProvider1));
 
         assertEquals(3, bqModuleMetadata.size());
-        assertTrue(bqModuleMetadata.contains(testModuleProvider1));
-        assertTrue(bqModuleMetadata.contains(testModuleProvider2));
-        assertTrue(bqModuleMetadata.contains(testModuleProvider3));
+        assertTrue(bqModuleMetadata.contains(metadata1));
+        assertTrue(bqModuleMetadata.contains(metadata2));
+        assertTrue(bqModuleMetadata.contains(metadata3));
 
-        verify(testModuleProvider1, new AtLeast(1)).dependencies();
-        verify(testModuleProvider1, new AtLeast(1)).moduleBuilder();
-        verify(testModuleProvider2, new AtLeast(1)).dependencies();
-        verify(testModuleProvider2, new AtLeast(1)).moduleBuilder();
-        verify(testModuleProvider3, new AtLeast(1)).dependencies();
-        verify(testModuleProvider3, new AtLeast(1)).moduleBuilder();
+        verify(testModuleProvider1, times(1)).dependencies();
+        verify(testModuleProvider1, times(1)).moduleBuilder();
+        verify(testModuleProvider2, times(1)).dependencies();
+        verify(testModuleProvider2, times(1)).moduleBuilder();
+        verify(testModuleProvider3, times(1)).dependencies();
+        verify(testModuleProvider3, times(1)).moduleBuilder();
 
         verifyNoMoreInteractions(testModuleProvider1, testModuleProvider2, testModuleProvider3);
     }
@@ -158,16 +154,16 @@ public class BootiqueUtilsTest {
                 BootiqueUtils.moduleProviderDependencies(singletonList(testModuleProvider1));
 
         assertEquals(3, bqModuleMetadata.size());
-        assertTrue(bqModuleMetadata.contains(testModuleProvider1));
-        assertTrue(bqModuleMetadata.contains(testModuleProvider2));
-        assertTrue(bqModuleMetadata.contains(testModuleProvider3));
+        assertTrue(bqModuleMetadata.contains(metadata1));
+        assertTrue(bqModuleMetadata.contains(metadata2));
+        assertTrue(bqModuleMetadata.contains(metadata3));
 
-        verify(testModuleProvider1, new AtLeast(1)).dependencies();
-        verify(testModuleProvider1, new AtLeast(1)).moduleBuilder();
-        verify(testModuleProvider2, new AtLeast(1)).dependencies();
-        verify(testModuleProvider2, new AtLeast(1)).moduleBuilder();
-        verify(testModuleProvider3, new AtLeast(1)).dependencies();
-        verify(testModuleProvider3, new AtLeast(1)).moduleBuilder();
+        verify(testModuleProvider1, times(1)).dependencies();
+        verify(testModuleProvider1, times(1)).moduleBuilder();
+        verify(testModuleProvider2, times(1)).dependencies();
+        verify(testModuleProvider2, times(1)).moduleBuilder();
+        verify(testModuleProvider3, times(1)).dependencies();
+        verify(testModuleProvider3, times(1)).moduleBuilder();
 
         verifyNoMoreInteractions(testModuleProvider1, testModuleProvider2, testModuleProvider3);
     }


### PR DESCRIPTION
This PR adds `BQModuleId` that ensures that each module is defined once.