### PR TITLE
added docs for using Gradle

### DIFF
--- a/bootique-docs/src/main/asciidoc/bootique-docs/_chapters/_02_programming.adoc
+++ b/bootique-docs/src/main/asciidoc/bootique-docs/_chapters/_02_programming.adoc
@@ -560,6 +560,9 @@ it will likely reduce the amount of bridging needed to route all logs to a singl
 
 For better control over logging a standard module called `bootique-logback` is available, that integrates http://logback.qos.ch/[Logback framework] in the app. It seamlessly bridges SLF4J (so you keep using SLF4J in the code), and allows to configure logging via YAML config file, including appenders (file, console, etc.) and per class/package log levels. Just like any other module, `bootique-logback` can be enabled by simply adding it to the pom.xml dependencies, assuming `autoLoadModules()` is in effect:
 
+.Maven
+[%collapsible%open]
+====
 [source,xml]
 ----
 <dependency>
@@ -567,6 +570,18 @@ For better control over logging a standard module called `bootique-logback` is a
     <artifactId>bootique-logback</artifactId>
 </dependency>
 ----
+====
+
+.Gradle
+[%collapsible]
+====
+[source,groovy]
+----
+{
+  implementation: 'io.bootique.logback:bootique-logback'
+}
+----
+====
 
 See `bootique-logback` module http://bootique.io/docs/0/bootique-logback-docs/[documentation] for further details.
 

--- a/bootique-docs/src/main/asciidoc/bootique-docs/_chapters/_03_testing.adoc
+++ b/bootique-docs/src/main/asciidoc/bootique-docs/_chapters/_03_testing.adoc
@@ -32,6 +32,10 @@ This chapter is about the core test framework. For module-specific test APIs (e.
 described here.
 
 To start using Bootique test extensions, import the following module in the "test" scope:
+
+.Maven
+[%collapsible%open]
+====
 [source,xml]
 ----
 <dependency>
@@ -40,6 +44,18 @@ To start using Bootique test extensions, import the following module in the "tes
     <scope>test</scope>
 </dependency>
 ----
+====
+
+.Gradle
+[%collapsible]
+====
+[source,groovy]
+----
+{
+  testImplementation: 'io.bootique:bootique-junit5:test'
+}
+----
+====
 
 Each test class using Bootique extensions must be annotated with `@BQTest`:
 

--- a/bootique-docs/src/main/asciidoc/getting-started/_chapters/_01_hello_world.adoc
+++ b/bootique-docs/src/main/asciidoc/getting-started/_chapters/_01_hello_world.adoc
@@ -20,6 +20,9 @@ The goal of this chapter is to write a simple REST app using Bootique.
 Let's start with a new Java Maven project created in your favorite IDE.
 Your `pom.xml` in addition to the required project information tags will need to declare a few BOM ("Bill of Material") imports in the `&lt;dependencyManagement/&gt;` section:
 
+.Maven
+[%collapsible%open]
+====
 [source,xml,subs="attributes+"]
 ----
 <dependencyManagement>
@@ -34,10 +37,25 @@ Your `pom.xml` in addition to the required project information tags will need to
   </dependencies>
 </dependencyManagement>
 ----
+====
+
+.Gradle
+[%collapsible]
+====
+[source,groovy,subs="attributes"]
+----
+dependencies {
+    implementation platform('io.bootique.bom:bootique-bom:{bootique_version}')
+}
+----
+====
 
 This will allow `<dependencies/>` section that will follow shortly to include various Bootique modules and not worry about their individual versions.
 So let's create this section and import a few modules:
 
+.Maven
+[%collapsible%open]
+====
 [source,xml]
 ----
 <dependencies>
@@ -53,6 +71,19 @@ So let's create this section and import a few modules:
   </dependency>
 </dependencies>
 ----
+====
+
+.Gradle
+[%collapsible]
+====
+[source,groovy]
+----
+dependencies {
+    implementation 'io.bootique.jersey:bootique-jersey:compile'
+    implementation 'io.bootique.logback:bootique-logback:compile'
+}
+----
+====
 
 As you see we want a `bootique-jersey` and `bootique-logback` modules in our app.
 Those may depend on other modules, but we don't have to think about it.

--- a/bootique-docs/src/main/asciidoc/getting-started/_chapters/_04_packaging.adoc
+++ b/bootique-docs/src/main/asciidoc/getting-started/_chapters/_04_packaging.adoc
@@ -22,6 +22,9 @@ Now let's package our app as a runnable "fat" jar to be able to run it from comm
 Assembling "fat" jar requires a bit of configuration of the Maven `maven-shade-plugin`.
 To simplify it, you can set a parent of your `pom.xml` to be a standard Bootique parent:
 
+.Maven
+[%collapsible%open]
+====
 [source,xml,subs="attributes+"]
 ----
 <parent>
@@ -30,9 +33,24 @@ To simplify it, you can set a parent of your `pom.xml` to be a standard Bootique
     <version>{bootique_parent_version}</version>
 </parent>
 ----
+====
+
+For gradle you can set the parent of your `settings.gradle`
+
+.Gradle
+[%collapsible]
+====
+[source,groovy]
+----
+include 'io.bootique.parent:bootique-parent{bootique_parent_version}'
+----
+====
 
 Other required `pom.xml` additions:
 
+.Maven
+[%collapsible%open]
+====
 [source,xml]
 ----
 <properties>
@@ -51,6 +69,16 @@ Other required `pom.xml` additions:
     </plugins>
 </build>
 ----
+====
+
+.Gradle
+[%collapsible]
+====
+[source,groovy]
+----
+mainClassName = 'io.bootique.test.Application'
+----
+====
 
 Once this is setup you can build and run the app:
 


### PR DESCRIPTION
Sample Maven and Gradle dependencies are provided as dropdown text. Maven dependencies are open by default.