### PR TITLE
Added github action that runs mvn clean verify on each push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+---
+name: Java CI
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macOS-latest, windows-latest]
+        java: [8, 11, 15]
+      fail-fast: false
+      max-parallel: 4
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Verify with Maven
+        run: mvn clean verify
+
+...


### PR DESCRIPTION
Of course travis can do the same, just thought having everything in one place might also be neat. Did not open an issue for that because it doesn't affect the code itself.
With the current action on each push mvn clean verify will run on Ubuntu 18.04, latest Mac OS and latest windows using JDK 8, 11, and 15.