### PR TITLE
fix: remove expressions like [...] from paths in search of field. Now…

### DIFF
--- a/bootique/src/main/java/io/bootique/meta/module/ModuleMetadata.java
+++ b/bootique/src/main/java/io/bootique/meta/module/ModuleMetadata.java
@@ -20,12 +20,7 @@
 package io.bootique.meta.module;
 
 import io.bootique.meta.MetadataNode;
-import io.bootique.meta.config.ConfigListMetadata;
-import io.bootique.meta.config.ConfigMapMetadata;
-import io.bootique.meta.config.ConfigMetadataNode;
-import io.bootique.meta.config.ConfigMetadataVisitor;
-import io.bootique.meta.config.ConfigObjectMetadata;
-import io.bootique.meta.config.ConfigValueMetadata;
+import io.bootique.meta.config.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -161,10 +156,16 @@ public class ModuleMetadata implements MetadataNode {
     private String[] splitFirstComponent(String configPath) {
         int dot = configPath.indexOf('.');
 
-        return dot < 0 ? new String[]{configPath, ""} : new String[]{
-                configPath.substring(0, dot),
-                configPath.substring(dot + 1)
-        };
+        if (dot < 0) {
+            int openBranchIndex = configPath.indexOf("[");
+            return openBranchIndex < 0 ? new String[]{configPath, ""}
+                    : new String[]{configPath.substring(0, openBranchIndex), ""};
+        } else {
+            return new String[]{
+                    configPath.substring(0, dot),
+                    configPath.substring(dot + 1)
+            };
+        }
     }
 
     public static class Builder {

--- a/bootique/src/test/java/io/bootique/Bootique_DeclareVarsIT.java
+++ b/bootique/src/test/java/io/bootique/Bootique_DeclareVarsIT.java
@@ -154,7 +154,6 @@ public class Bootique_DeclareVarsIT {
     }
 
     @Test
-    @Disabled("Declared vars with array indices are excluded from help #292")
     public void testInHelpWithList() {
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
#292 

- remove expression like [..] with numbers inside from path to fields, when we check if path to field is correct. So search of expressions like a[0], where a - name of list or array, will return field a instead of nothing and variable, which should be injected in field with this path, will be added correctly.
- remove unnecessary annotation "Disabled" from test, which doesn't fail now