### PR TITLE
Test case refactoring: improve test case generality

### DIFF
--- a/bootique/src/test/java/io/bootique/BootiqueExceptionsHandlerIT.java
+++ b/bootique/src/test/java/io/bootique/BootiqueExceptionsHandlerIT.java
@@ -44,9 +44,7 @@ public class BootiqueExceptionsHandlerIT {
     public void testCli_BadOption() {
         CommandOutcome out = Bootique.app("-x").exec();
 
-        assertEquals(1, out.getExitCode());
-        assertNull(out.getException());
-        assertEquals("x is not a recognized option", out.getMessage());
+        this.assertErrorOutcome(out, "x is not a recognized option");
     }
 
     @Test
@@ -80,9 +78,7 @@ public class BootiqueExceptionsHandlerIT {
                 )
                 .exec();
 
-        assertEquals(1, out.getExitCode());
-        assertNull(out.getException());
-        assertEquals("CLI options match multiple commands: xcommand, ycommand.", out.getMessage());
+        this.assertErrorOutcome(out, "CLI options match multiple commands: xcommand, ycommand.");
     }
 
     @Test
@@ -105,9 +101,7 @@ public class BootiqueExceptionsHandlerIT {
                 .module(b -> BQCoreModule.extend(b).addCommand(TestCommand.class))
                 .exec();
 
-        assertEquals(1, out.getExitCode());
-        assertNull(out.getException());
-        assertEquals("Invalid config resource url: nosuchprotocol://myconfig", out.getMessage());
+        this.assertErrorOutcome(out, "Invalid config resource url: nosuchprotocol://myconfig");
     }
 
     @Test
@@ -118,9 +112,7 @@ public class BootiqueExceptionsHandlerIT {
                 .module(b -> BQCoreModule.extend(b).addCommand(TestCommand.class))
                 .exec();
 
-        assertEquals(1, out.getExitCode());
-        assertNull(out.getException());
-        assertEquals("Invalid config resource url: no_such_protocol://myconfig", out.getMessage());
+        this.assertErrorOutcome(out, "Invalid config resource url: no_such_protocol://myconfig");
     }
 
     @Test
@@ -129,9 +121,7 @@ public class BootiqueExceptionsHandlerIT {
                 .module(new ModuleWithProviderMethodBqException())
                 .exec();
 
-        assertEquals(1, out.getExitCode());
-        assertNull(out.getException());
-        assertEquals("test provider exception", out.getMessage());
+        this.assertErrorOutcome(out, "test provider exception");
     }
 
     @Test
@@ -358,5 +348,11 @@ public class BootiqueExceptionsHandlerIT {
         public Collection<Class<? extends BQModule>> overrides() {
             return Collections.singleton(BQCoreModule.class);
         }
+    }
+
+    public void assertErrorOutcome(CommandOutcome out, String outMessage) {
+        assertEquals(1, out.getExitCode());
+        assertNull(out.getException());
+        assertEquals(outMessage, out.getMessage());
     }
 }

--- a/bootique/src/test/java/io/bootique/config/jackson/merger/InPlacePropertiesMergerTest.java
+++ b/bootique/src/test/java/io/bootique/config/jackson/merger/InPlacePropertiesMergerTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Arrays;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -82,38 +84,22 @@ public class InPlacePropertiesMergerTest {
 
     @Test
     public void testApply_ObjectArray() {
-
-        Map<String, String> props = Collections.singletonMap("a[1]", "50");
-        InPlacePropertiesMerger overrider = new InPlacePropertiesMerger(props);
-
-        JsonNode node = YamlReader.read("a:\n" +
-                "  - 1\n" +
-                "  - 5\n" +
-                "  - 10");
-        overrider.apply(node);
-
-        ArrayNode array = (ArrayNode) node.get("a");
-        assertEquals(3, array.size());
-        assertEquals(1, array.get(0).asInt());
-        assertEquals(50, array.get(1).asInt());
-        assertEquals(10, array.get(2).asInt());
+        this.testApply_ObjectArrayTemplate(new ArrayList<Integer>(Arrays.asList(1, 50, 10)), "a[1]", "50", "a:\n" + "  - 1\n" + "  - 5\n" + "  - 10", "a");
     }
 
     @Test
     public void testApply_ObjectArray_PastEnd() {
+        this.testApply_ObjectArrayTemplate(new ArrayList<Integer>(Arrays.asList(1, 5, 50)), "a[2]", "50", "a:\n" + "  - 1\n" + "  - 5", "a");
+    }
 
-        Map<String, String> props = Collections.singletonMap("a[2]", "50");
+    public void testApply_ObjectArrayTemplate(ArrayList<Integer> expectedArray, String key, String value, String arrayContent, String arrayName) {
+        Map<String, String> props = Collections.singletonMap(key, value);
         InPlacePropertiesMerger overrider = new InPlacePropertiesMerger(props);
-
-        JsonNode node = YamlReader.read("a:\n" +
-                "  - 1\n" +
-                "  - 5");
+        JsonNode node = YamlReader.read(arrayContent);
         overrider.apply(node);
-
-        ArrayNode array = (ArrayNode) node.get("a");
-        assertEquals(3, array.size());
-        assertEquals(1, array.get(0).asInt());
-        assertEquals(5, array.get(1).asInt());
-        assertEquals(50, array.get(2).asInt());
+        ArrayNode array = (ArrayNode) node.get(arrayName);
+        ArrayList<Integer> actualArray = new ArrayList<Integer>();
+        array.elements().forEachRemaining(i -> actualArray.add(i.asInt()));
+        assertEquals(expectedArray, actualArray);
     }
 }

--- a/bootique/src/test/java/io/bootique/config/jackson/path/PathSegmentTest.java
+++ b/bootique/src/test/java/io/bootique/config/jackson/path/PathSegmentTest.java
@@ -115,30 +115,18 @@ public class PathSegmentTest {
     public void testLastPathComponent_ArrayRootValue() {
         JsonNode node = YamlReader.read("- 1\n- 2");
 
-        Optional<PathSegment<?>> last0 = PathSegment.create(node, "[0]").lastPathComponent();
-        assertTrue(last0.isPresent(), "Couldn't resolve '[0]' path");
-        assertNotNull(last0.get().getNode(), "Couldn't resolve '[0]' path");
-        assertEquals(1, last0.get().getNode().asInt());
+        this.assertCanCreateValidPathSegment(node, "[0]", 1);
 
-        Optional<PathSegment<?>> last1 = PathSegment.create(node, "[1]").lastPathComponent();
-        assertTrue(last1.isPresent(), "Couldn't resolve '[1]' path");
-        assertNotNull(last1.get().getNode(), "Couldn't resolve '[1]' path");
-        assertEquals(2, last1.get().getNode().asInt());
+        this.assertCanCreateValidPathSegment(node, "[1]", 2);
     }
 
     @Test
     public void testLastPathComponent_ArrayValue() {
         JsonNode node = YamlReader.read("a:\n  - 1\n  - 2");
 
-        Optional<PathSegment<?>> last0 = PathSegment.create(node, "a[0]").lastPathComponent();
-        assertTrue(last0.isPresent(), "Couldn't resolve 'a[0]' path");
-        assertNotNull(last0.get().getNode(), "Couldn't resolve 'a[0]' path");
-        assertEquals(1, last0.get().getNode().asInt());
+        this.assertCanCreateValidPathSegment(node, "a[0]", 1);
 
-        Optional<PathSegment<?>> last1 = PathSegment.create(node, "a[1]").lastPathComponent();
-        assertTrue(last1.isPresent(), "Couldn't resolve 'a[1]' path");
-        assertNotNull(last1.get().getNode(), "Couldn't resolve 'a[1]' path");
-        assertEquals(2, last1.get().getNode().asInt());
+        this.assertCanCreateValidPathSegment(node, "a[1]", 2);
     }
 
     @Test
@@ -162,10 +150,14 @@ public class PathSegmentTest {
     @Test
     public void testLastPathComponent_ArrayObject() {
         JsonNode node = YamlReader.read("a:\n  - b: 1\n  - b: 2");
-        Optional<PathSegment<?>> last = PathSegment.create(node, "a[1].b").lastPathComponent();
 
-        assertTrue(last.isPresent(), "Couldn't resolve 'a[1].b' path");
-        assertNotNull(last.get().getNode(), "Couldn't resolve 'a[1].b' path");
-        assertEquals(2, last.get().getNode().asInt());
+        this.assertCanCreateValidPathSegment(node, "a[1].b", 2);
+    }
+
+    public void assertCanCreateValidPathSegment(JsonNode t, String path, int expectedValue) {
+        Optional<PathSegment<?>> last = PathSegment.create(t, path).lastPathComponent();
+        assertTrue(last.isPresent(), "Couldn't resolve '" + path + "' path");
+        assertNotNull(last.get().getNode(), "Couldn't resolve '" + path + "' path");
+        assertEquals(expectedValue, last.get().getNode().asInt());
     }
 }

--- a/bootique/src/test/java/io/bootique/resource/ResourceFactoryTest.java
+++ b/bootique/src/test/java/io/bootique/resource/ResourceFactoryTest.java
@@ -97,17 +97,19 @@ public class ResourceFactoryTest {
 
 	@Test
 	public void testGetUrls_ClasspathUrl() {
-		Collection<URL> urls = new ResourceFactory("classpath:io/bootique/config/test2.yml").getUrls();
-		assertEquals(1, urls.size());
-		String u1 = urls.iterator().next().toString();
-		assertTrue(u1.endsWith("io/bootique/config/test2.yml"), u1);
+		this.testGetUrlsTemplate("classpath:io/bootique/config/test2.yml", 1, "io/bootique/config/test2.yml");
 	}
 
 	@Test
 	public void testGetUrls_File() {
-		Collection<URL> urls = new ResourceFactory("src/test/resources/io/bootique/config/test1.yml").getUrls();
-		assertEquals(1, urls.size());
+		this.testGetUrlsTemplate("src/test/resources/io/bootique/config/test1.yml", 1,
+				"src/test/resources/io/bootique/config/test1.yml");
+	}
+
+	public void testGetUrlsTemplate(String location, int numOfUrls, String firstUrlEnding) {
+		Collection<URL> urls = new ResourceFactory(location).getUrls();
+		assertEquals(numOfUrls, urls.size());
 		String u1 = urls.iterator().next().toString();
-		assertTrue(u1.endsWith("src/test/resources/io/bootique/config/test1.yml"), u1);
+		assertTrue(u1.endsWith(firstUrlEnding), u1);
 	}
 }


### PR DESCRIPTION
As part of a research project at the University of Waterloo, we are exploring automatic test refactoring tools and submitting vetted proposed refactorings upstream. These refactorings make it easier to add additional related test methods, should help with the maintainability of the tests, and reduce repeated code. In this pull request, we have four refactoring cases involving 14 test methods. We've checked all cases and ensured that all the test runs pass successfully.
If it helps, we can also propose a test case that uses these 14 refactored test methods. We explained each of the four refactoring cases below.

1. BootiqueExceptionsHandlerIT.java
     There is a standard procedure to verify the expected behavior of an erring command outcome that includes checking if the exit code is one, checking the existence of exceptions, and checking the outcome's message. We create the "assertErrorOutcome(CommandOutcome out, String outMessage)" parametrized method, which allows you to add similar test cases with different arguments out and outMessage.

1. InPlacePropertiesMergerTest.java
     This refactoring is a bit more specific. "testApply_ObjectArray()" and "testApply_ObjectArray_PastEnd()" test methods only differ in the string of array content, expected array, and the key string (for Collections.singletonMap). We create the "testApply_ObjectArrayTemplate(ArrayList<Integer> expectedArray, String key, String value, String arrayContent, String arrayName)", which allows you to add similar test cases with different arguments. We also replace the multiple assertEquals for every member of the list with one assertEquals for the actual list and expected list.

1. PathSegmentTest.java
     To check the possibility of creating a valid path segment for a given JsonNode and path, we follow a standard procedure. By creating the "assertCanCreateValidPathSegment(JsonNode t, String path, int expectedValue)" parametrized method, we're encapsulating that procedure, which allows you to add similar test cases.

1. ResourceFactoryTest.java
     Both "testGetUrls_ClasspathUrl()" and "testGetUrls_File()" test methods get URLs from a resource factory, check the number of URLs, and check the ending of the first URL. We create the "testGetUrlsTemplate(String location, int numOfUrls, String firstUrlEnding)" parametrized method, which allows you to add similar test cases with different arguments location, numOfUrls, and firstUrlEnding.
