### PR TITLE
Transform ArrayList to HashSet

### DIFF
--- a/bootique-junit5/src/main/java/io/bootique/junit5/BQRuntimeChecker.java
+++ b/bootique-junit5/src/main/java/io/bootique/junit5/BQRuntimeChecker.java
@@ -23,6 +23,7 @@ import io.bootique.di.BQModule;
 import io.bootique.meta.module.ModuleMetadata;
 import io.bootique.meta.module.ModulesMetadata;
 
+import java.util.HashSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -46,11 +47,11 @@ public class BQRuntimeChecker {
 
         ModulesMetadata modulesMetadata = runtime.getInstance(ModulesMetadata.class);
 
-        List<String> actualModules = modulesMetadata
+        HashSet<String> actualModules = new HashSet<>(modulesMetadata
                 .getModules()
                 .stream()
                 .map(ModuleMetadata::getName)
-                .collect(toList());
+                .collect(toList()));
 
         List<String> missingModules = new ArrayList<>();
         Stream.of(expectedModules)

--- a/bootique/src/main/java/io/bootique/ModuleGraph.java
+++ b/bootique/src/main/java/io/bootique/ModuleGraph.java
@@ -110,11 +110,12 @@ class ModuleGraph {
             );
         }
 
+        Set<BQModuleMetadata> resultSet = new HashSet<>(result);
         // Check that we have used the entire graph (if not, there was a cycle)
         if (result.size() != neighbors.size()) {
             Set<BQModuleMetadata> remainingKeys = new HashSet<>(neighbors.keySet());
             String cycleString = remainingKeys.stream()
-                    .filter(o -> !result.contains(o))
+                    .filter(o -> !resultSet.contains(o))
                     .map(BQModuleMetadata::getName)
                     .collect(Collectors.joining(" -> "));
             throw new BootiqueException(1, "Circular override dependency between DI modules: " + cycleString);

--- a/bootique/src/main/java/io/bootique/config/jackson/CliCustomOptionsConfigurationLoader.java
+++ b/bootique/src/main/java/io/bootique/config/jackson/CliCustomOptionsConfigurationLoader.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.HashSet;
 
 /**
  * Loads and merges configuration passed via custom CLI options other than "--config". Custom CLI options can
@@ -114,10 +115,7 @@ public class CliCustomOptionsConfigurationLoader implements JsonConfigurationLoa
 
     private OptionMetadata findMetadata(OptionSpec<?> option) {
 
-        List<String> optionNames = option.options();
-
-        // TODO: allow lookup of option metadata by name to avoid linear scans...
-        // Though we are dealing with small collection, so shouldn't be too horrible.
+        Set<String> optionNames = new HashSet<>(option.options());
 
         for (OptionMetadata omd : optionMetadata) {
             if (optionNames.contains(omd.getName())) {

--- a/bootique/src/main/java/io/bootique/help/config/HelpConfigCommand.java
+++ b/bootique/src/main/java/io/bootique/help/config/HelpConfigCommand.java
@@ -29,6 +29,8 @@ import io.bootique.command.CommandWithMetadata;
 import io.bootique.log.BootLogger;
 
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.function.Predicate;
 
 public class HelpConfigCommand extends CommandWithMetadata {
@@ -48,7 +50,7 @@ public class HelpConfigCommand extends CommandWithMetadata {
 
     @Override
     public CommandOutcome run(Cli cli) {
-        List<String> arguments = cli.standaloneArguments();
+        Set<String> arguments = new HashSet<>(cli.standaloneArguments());
 
         Predicate<MetadataNode> predicate = (arguments.size() == 0)
                 ? o -> true


### PR DESCRIPTION
Hi,
We find that the List `actualModules` allocated at line 49 in the file `bootique-junit5/src/main/java/io/bootique/junit5/BQRuntimeChecker.java` is only used to check whether an element is stored in the container. The method `contains` at line 61 runs in linear time complexity. 

To achieve the same functionality, maybe a `HashSet` can provide a more efficient implementation. We can just construct a `HashSet` from the list directly at line 49 and then utilize the `contains` method of `HashSet` to perform the searching in amortized constant time. 

We discovered this inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well. 

Bests



Ditto
