### PR TITLE
Add semantic CLI option API

### DIFF
--- a/bootique-docs/src/test/java/io/bootique/docs/programming/configuration/fileLoading/MyModule.java
+++ b/bootique-docs/src/test/java/io/bootique/docs/programming/configuration/fileLoading/MyModule.java
@@ -3,7 +3,9 @@ package io.bootique.docs.programming.configuration.fileLoading;
 import io.bootique.BQCoreModule;
 import io.bootique.BQModule;
 import io.bootique.di.Binder;
-import io.bootique.meta.application.OptionMetadata;
+import io.bootique.option.ConfigResourceOption;
+import io.bootique.option.ConfigValueOption;
+import io.bootique.option.Option;
 
 public class MyModule implements BQModule {
 
@@ -16,25 +18,21 @@ public class MyModule implements BQModule {
 
 
         // tag::MyModuleQAOption[]
-        OptionMetadata o = OptionMetadata.builder("qa")
+        ConfigResourceOption o = Option.configResource("qa", "classpath:a/b/qa.yml")
                 .description("when present, uses QA config")
                 .build();
 
-        BQCoreModule.extend(binder)
-                .addOption(o)
-                .mapConfigResource(o.getName(), "classpath:a/b/qa.yml");
+        BQCoreModule.extend(binder).addOption(o);
         // end::MyModuleQAOption[]
 
 
         // tag::MyModuleDBOption[]
-        OptionMetadata o1 = OptionMetadata.builder("db")
+        ConfigValueOption o1 = Option.configValue("db", "jdbc.mydb.url")
                 .description("specifies database URL")
                 .valueOptionalWithDefault("jdbc:mysql://127.0.0.1:3306/mydb")
                 .build();
 
-        BQCoreModule.extend(binder)
-                .addOption(o1)
-                .mapConfigPath(o1.getName(), "jdbc.mydb.url");
+        BQCoreModule.extend(binder).addOption(o1);
         // end::MyModuleDBOption[]
 
     }

--- a/bootique-docs/src/test/java/io/bootique/docs/programming/configuration/yaml/MyModule.java
+++ b/bootique-docs/src/test/java/io/bootique/docs/programming/configuration/yaml/MyModule.java
@@ -6,7 +6,9 @@ import io.bootique.config.ConfigurationFactory;
 import io.bootique.di.Binder;
 import io.bootique.di.Provides;
 import io.bootique.docs.programming.configuration.MyService;
-import io.bootique.meta.application.OptionMetadata;
+import io.bootique.option.ConfigResourceOption;
+import io.bootique.option.ConfigValueOption;
+import io.bootique.option.Option;
 import jakarta.inject.Singleton;
 
 // tag::MyModuleConfig[]
@@ -31,25 +33,21 @@ public class MyModule implements BQModule {
 
 
         // tag::MyModuleQAOption[]
-        OptionMetadata o = OptionMetadata.builder("qa")
+        ConfigResourceOption o = Option.configResource("qa", "classpath:a/b/qa.yml")
                 .description("when present, uses QA config")
                 .build();
 
-        BQCoreModule.extend(binder)
-                .addOption(o)
-                .mapConfigResource(o.getName(), "classpath:a/b/qa.yml");
+        BQCoreModule.extend(binder).addOption(o);
         // end::MyModuleQAOption[]
 
 
         // tag::MyModuleDBOption[]
-        OptionMetadata o1 = OptionMetadata.builder("db")
+        ConfigValueOption o1 = Option.configValue("db", "jdbc.mydb.url")
                 .description("specifies database URL")
                 .valueOptionalWithDefault("jdbc:mysql://127.0.0.1:3306/mydb")
                 .build();
 
-        BQCoreModule.extend(binder)
-                .addOption(o1)
-                .mapConfigPath(o1.getName(), "jdbc.mydb.url");
+        BQCoreModule.extend(binder).addOption(o1);
         // end::MyModuleDBOption[]
 
 

--- a/bootique-docs/src/test/java/io/bootique/docs/programming/options/configuration/MyOption.java
+++ b/bootique-docs/src/test/java/io/bootique/docs/programming/options/configuration/MyOption.java
@@ -3,7 +3,9 @@ package io.bootique.docs.programming.options.configuration;
 import io.bootique.BQCoreModule;
 import io.bootique.BQModule;
 import io.bootique.di.Binder;
-import io.bootique.meta.application.OptionMetadata;
+import io.bootique.option.ConfigResourceOption;
+import io.bootique.option.ConfigValueOption;
+import io.bootique.option.Option;
 
 public class MyOption implements BQModule {
 
@@ -11,25 +13,27 @@ public class MyOption implements BQModule {
     public void configure(Binder binder) {
 // tag::OptionsConfig[]
         // Starting the app with "--my-opt=x" will set "jobs.myjob.param" value to "x"
-        BQCoreModule.extend(binder)
-                .addOption(OptionMetadata.builder("my-opt").build())
-                .mapConfigPath("my-opt", "jobs.myjob.param");
+        ConfigValueOption opt = Option.configValue("my-opt", "jobs.myjob.param").build();
+
+        BQCoreModule.extend(binder).addOption(opt);
         // end::OptionsConfig[]
 
 
 // tag::OptionsPredefined[]
         // Starting the app with "--my-opt" will set "jobs.myjob.param" value to "y"
-        BQCoreModule.extend(binder)
-                .addOption(OptionMetadata.builder("my-opt").valueOptionalWithDefault("y").build())
-                .mapConfigPath("my-opt", "jobs.myjob.param");
+        ConfigValueOption opt1 = Option.configValue("my-opt", "jobs.myjob.param")
+                .valueOptionalWithDefault("y")
+                .build();
+
+        BQCoreModule.extend(binder).addOption(opt1);
         // end::OptionsPredefined[]
 
 
 // tag::OptionsYaml[]
         // Starting the app with "--my-opt" is equivalent to starting with "--config=classpath:xyz.yml"
-        BQCoreModule.extend(binder)
-                .addOption(OptionMetadata.builder("my-opt").build())
-                .mapConfigResource("my-opt", "classpath:xyz.yml");
+        ConfigResourceOption opt2 = Option.configResource("my-opt", "classpath:xyz.yml").build();
+
+        BQCoreModule.extend(binder).addOption(opt2);
         // end::OptionsYaml[]
 
     }

--- a/bootique/src/main/java/io/bootique/BQCoreModule.java
+++ b/bootique/src/main/java/io/bootique/BQCoreModule.java
@@ -54,6 +54,7 @@ import io.bootique.log.BootLogger;
 import io.bootique.meta.application.ApplicationMetadata;
 import io.bootique.meta.application.ApplicationMetadataFactory;
 import io.bootique.meta.application.OptionMetadata;
+import io.bootique.option.Option;
 import io.bootique.meta.config.ConfigHierarchyResolver;
 import io.bootique.meta.config.ConfigMetadataCompiler;
 import io.bootique.meta.module.ModulesMetadata;
@@ -163,11 +164,11 @@ public class BQCoreModule implements BQModule {
         binder.bind(String[].class, Args.class).toInstance(args);
     }
 
-    OptionMetadata createConfigOption() {
-        return OptionMetadata
-                .builder(CliConfigurationLoader.CONFIG_OPTION,
-                        "Specifies YAML config location, which can be a file path or a URL.")
-                .valueRequired("yaml_location").build();
+    Option createConfigOption() {
+        return Option.valueOption(CliConfigurationLoader.CONFIG_OPTION)
+                .description("Specifies YAML config location, which can be a file path or a URL.")
+                .valueRequired("yaml_location")
+                .build();
     }
 
     @Provides

--- a/bootique/src/main/java/io/bootique/BQCoreModuleExtender.java
+++ b/bootique/src/main/java/io/bootique/BQCoreModuleExtender.java
@@ -34,6 +34,9 @@ import io.bootique.di.TypeLiteral;
 import io.bootique.env.DeclaredVariable;
 import io.bootique.help.ValueObjectDescriptor;
 import io.bootique.meta.application.OptionMetadata;
+import io.bootique.option.ConfigResourceOption;
+import io.bootique.option.ConfigValueOption;
+import io.bootique.option.Option;
 import jakarta.inject.Provider;
 
 import java.util.Map;
@@ -248,6 +251,19 @@ public class BQCoreModuleExtender extends ModuleExtender<BQCoreModuleExtender> {
         return this;
     }
 
+    public BQCoreModuleExtender addOption(Option option) {
+        if (option != null) {
+            addOption(option.getMetadata());
+
+            if (option instanceof ConfigResourceOption configResourceOption) {
+                mapConfigResource(option.getMetadata().getName(), configResourceOption.getConfigResourceId());
+            } else if (option instanceof ConfigValueOption configValueOption) {
+                mapConfigPath(option.getMetadata().getName(), configValueOption.getConfigPath());
+            }
+        }
+        return this;
+    }
+
     /**
      * Adds zero or more new options to the list of Bootique CLI options.
      *
@@ -255,6 +271,13 @@ public class BQCoreModuleExtender extends ModuleExtender<BQCoreModuleExtender> {
      * @return this extender instance.
      */
     public BQCoreModuleExtender addOptions(OptionMetadata... options) {
+        if (options != null) {
+            asList(options).forEach(this::addOption);
+        }
+        return this;
+    }
+
+    public BQCoreModuleExtender addOptions(Option... options) {
         if (options != null) {
             asList(options).forEach(this::addOption);
         }

--- a/bootique/src/main/java/io/bootique/BQCoreModuleExtender.java
+++ b/bootique/src/main/java/io/bootique/BQCoreModuleExtender.java
@@ -218,7 +218,9 @@ public class BQCoreModuleExtender extends ModuleExtender<BQCoreModuleExtender> {
      * @param configResourceId a resource path compatible with {@link io.bootique.resource.ResourceFactory} denoting
      *                         a configuration source. E.g. "a/b/my.yml", or "classpath:com/foo/another.yml".
      * @return this extender instance.
+     * @deprecated use {@link #addOption(Option)} with {@link io.bootique.option.ConfigResourceOption}
      */
+    @Deprecated(since = "4.0")
     public BQCoreModuleExtender mapConfigResource(String optionName, String configResourceId) {
         // using SetBuilder to support multiple decorators for the same option
         contributeOptionDecorators().addInstance(new OptionRefWithConfig(optionName, configResourceId));
@@ -234,7 +236,9 @@ public class BQCoreModuleExtender extends ModuleExtender<BQCoreModuleExtender> {
      * @param configPath a dot-separated "path" that navigates configuration tree to the desired property.
      *                   E.g. "jdbc.myds.password".
      * @return this extender instance
+     * @deprecated use {@link #addOption(Option)} with {@link io.bootique.option.ConfigValueOption}
      */
+    @Deprecated(since = "4.0")
     public BQCoreModuleExtender mapConfigPath(String optionName, String configPath) {
         contributeOptionPathDecorators().addInstance(new OptionRefWithConfigPath(optionName, configPath));
         return this;
@@ -254,11 +258,13 @@ public class BQCoreModuleExtender extends ModuleExtender<BQCoreModuleExtender> {
     public BQCoreModuleExtender addOption(Option option) {
         if (option != null) {
             addOption(option.getMetadata());
-
-            if (option instanceof ConfigResourceOption configResourceOption) {
-                mapConfigResource(option.getMetadata().getName(), configResourceOption.getConfigResourceId());
-            } else if (option instanceof ConfigValueOption configValueOption) {
-                mapConfigPath(option.getMetadata().getName(), configValueOption.getConfigPath());
+            String name = option.getMetadata().getName();
+            if (option instanceof ConfigResourceOption cro) {
+                String configResourceId = cro.getConfigResourceId();
+                contributeOptionDecorators().addInstance(new OptionRefWithConfig(name, configResourceId));
+            } else if (option instanceof ConfigValueOption cvo) {
+                String configPath = cvo.getConfigPath();
+                contributeOptionPathDecorators().addInstance(new OptionRefWithConfigPath(name, configPath));
             }
         }
         return this;

--- a/bootique/src/main/java/io/bootique/command/Commands.java
+++ b/bootique/src/main/java/io/bootique/command/Commands.java
@@ -33,6 +33,7 @@ import io.bootique.help.HelpCommand;
 import io.bootique.log.BootLogger;
 import io.bootique.meta.application.ApplicationMetadata;
 import io.bootique.meta.application.OptionMetadata;
+import io.bootique.option.Option;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 
@@ -174,6 +175,10 @@ public class Commands implements BQModule {
         public Builder addOption(OptionMetadata option) {
             commands.options.add(option);
             return this;
+        }
+
+        public Builder addOption(Option option) {
+            return addOption(option.getMetadata());
         }
 
         /**

--- a/bootique/src/main/java/io/bootique/meta/application/CommandMetadata.java
+++ b/bootique/src/main/java/io/bootique/meta/application/CommandMetadata.java
@@ -21,6 +21,7 @@ package io.bootique.meta.application;
 
 import io.bootique.command.Command;
 import io.bootique.meta.MetadataNode;
+import io.bootique.option.Option;
 import io.bootique.names.ClassToName;
 
 import java.util.ArrayList;
@@ -204,6 +205,10 @@ public class CommandMetadata implements MetadataNode {
         public Builder addOption(OptionMetadata option) {
             this.metadata.options.add(option);
             return this;
+        }
+
+        public Builder addOption(Option option) {
+            return addOption(option.getMetadata());
         }
 
         public Builder addOptions(Collection<OptionMetadata> options) {

--- a/bootique/src/main/java/io/bootique/option/ConfigResourceOption.java
+++ b/bootique/src/main/java/io/bootique/option/ConfigResourceOption.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to ObjectStyle LLC under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ObjectStyle LLC licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.bootique.option;
+
+import io.bootique.meta.application.OptionMetadata;
+
+import java.util.Objects;
+
+/**
+ * A flag option that loads a configuration resource.
+ */
+public class ConfigResourceOption extends FlagOption {
+
+    private final String configResourceId;
+
+    protected ConfigResourceOption(OptionMetadata metadata, String configResourceId) {
+        super(metadata);
+        this.configResourceId = Objects.requireNonNull(configResourceId, "configResourceId is null");
+    }
+
+    public String getConfigResourceId() {
+        return configResourceId;
+    }
+
+    public static class Builder {
+
+        private final String configResourceId;
+        private final OptionMetadata.Builder delegate;
+
+        public Builder(String name, String configResourceId) {
+            this.configResourceId = Objects.requireNonNull(configResourceId, "configResourceId is null");
+            this.delegate = OptionMetadata.builder(name);
+        }
+
+        public Builder description(String description) {
+            delegate.description(description);
+            return this;
+        }
+
+        public Builder shortName(char shortName) {
+            delegate.shortName(shortName);
+            return this;
+        }
+
+        public Builder shortName(String shortName) {
+            delegate.shortName(shortName);
+            return this;
+        }
+
+        public ConfigResourceOption build() {
+            return new ConfigResourceOption(delegate.build(), configResourceId);
+        }
+    }
+}

--- a/bootique/src/main/java/io/bootique/option/ConfigValueOption.java
+++ b/bootique/src/main/java/io/bootique/option/ConfigValueOption.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to ObjectStyle LLC under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ObjectStyle LLC licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.bootique.option;
+
+import io.bootique.meta.application.OptionMetadata;
+
+import java.util.Objects;
+
+/**
+ * An option that binds its value to a configuration path.
+ */
+public class ConfigValueOption extends ValueOption {
+
+    private final String configPath;
+
+    protected ConfigValueOption(OptionMetadata metadata, String configPath) {
+        super(metadata);
+        this.configPath = Objects.requireNonNull(configPath, "configPath is null");
+    }
+
+    public String getConfigPath() {
+        return configPath;
+    }
+
+    public static class Builder {
+
+        private final String configPath;
+        private final OptionMetadata.Builder delegate;
+
+        public Builder(String name, String configPath) {
+            this.configPath = Objects.requireNonNull(configPath, "configPath is null");
+            this.delegate = OptionMetadata.builder(name);
+            this.delegate.valueRequired();
+        }
+
+        public Builder description(String description) {
+            delegate.description(description);
+            return this;
+        }
+
+        public Builder shortName(char shortName) {
+            delegate.shortName(shortName);
+            return this;
+        }
+
+        public Builder shortName(String shortName) {
+            delegate.shortName(shortName);
+            return this;
+        }
+
+        public Builder valueRequired() {
+            delegate.valueRequired();
+            return this;
+        }
+
+        public Builder valueRequired(String valueName) {
+            delegate.valueRequired(valueName);
+            return this;
+        }
+
+        public Builder valueOptional() {
+            delegate.valueOptional();
+            return this;
+        }
+
+        public Builder valueOptional(String valueName) {
+            delegate.valueOptional(valueName);
+            return this;
+        }
+
+        public Builder valueOptionalWithDefault(String defaultValue) {
+            delegate.valueOptionalWithDefault(defaultValue);
+            return this;
+        }
+
+        public Builder valueOptionalWithDefault(String valueName, String defaultValue) {
+            delegate.valueOptionalWithDefault(valueName, defaultValue);
+            return this;
+        }
+
+        public ConfigValueOption build() {
+            return new ConfigValueOption(delegate.build(), configPath);
+        }
+    }
+}

--- a/bootique/src/main/java/io/bootique/option/FlagOption.java
+++ b/bootique/src/main/java/io/bootique/option/FlagOption.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to ObjectStyle LLC under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ObjectStyle LLC licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.bootique.option;
+
+import io.bootique.meta.application.OptionMetadata;
+
+import java.util.Objects;
+
+/**
+ * A flag option without a value.
+ */
+public class FlagOption implements Option {
+
+    private final OptionMetadata metadata;
+
+    protected FlagOption(OptionMetadata metadata) {
+        this.metadata = Objects.requireNonNull(metadata, "metadata");
+    }
+
+    @Override
+    public OptionMetadata getMetadata() {
+        return metadata;
+    }
+
+    public static class Builder {
+
+        private final OptionMetadata.Builder delegate;
+
+        public Builder(String name) {
+            this.delegate = OptionMetadata.builder(name);
+        }
+
+        public Builder description(String description) {
+            delegate.description(description);
+            return this;
+        }
+
+        public Builder shortName(char shortName) {
+            delegate.shortName(shortName);
+            return this;
+        }
+
+        public Builder shortName(String shortName) {
+            delegate.shortName(shortName);
+            return this;
+        }
+
+        public FlagOption build() {
+            return new FlagOption(delegate.build());
+        }
+    }
+}

--- a/bootique/src/main/java/io/bootique/option/Option.java
+++ b/bootique/src/main/java/io/bootique/option/Option.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to ObjectStyle LLC under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ObjectStyle LLC licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.bootique.option;
+
+import io.bootique.cli.Cli;
+import io.bootique.meta.application.OptionMetadata;
+
+import java.util.Objects;
+
+/**
+ * A semantic CLI option abstraction that wraps {@link OptionMetadata}.
+ */
+public interface Option {
+
+    OptionMetadata getMetadata();
+
+    default boolean isSet(Cli cli) {
+        return Objects.requireNonNull(cli, "cli").hasOption(Objects.requireNonNull(getMetadata(), "metadata").getName());
+    }
+
+    static FlagOption.Builder flag(String name) {
+        return new FlagOption.Builder(name);
+    }
+
+    static ValueOption.Builder valueOption(String name) {
+        return new ValueOption.Builder(name);
+    }
+
+    static ConfigValueOption.Builder configValue(String name, String configPath) {
+        return new ConfigValueOption.Builder(name, configPath);
+    }
+
+    static ConfigResourceOption.Builder configResource(String name, String configResourceId) {
+        return new ConfigResourceOption.Builder(name, configResourceId);
+    }
+}

--- a/bootique/src/main/java/io/bootique/option/ValueOption.java
+++ b/bootique/src/main/java/io/bootique/option/ValueOption.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to ObjectStyle LLC under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ObjectStyle LLC licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.bootique.option;
+
+import io.bootique.cli.Cli;
+import io.bootique.meta.application.OptionMetadata;
+
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * An option that accepts a value.
+ */
+public class ValueOption implements Option {
+
+    private final OptionMetadata metadata;
+
+    protected ValueOption(OptionMetadata metadata) {
+        this.metadata = Objects.requireNonNull(metadata, "metadata");
+    }
+
+    @Override
+    public OptionMetadata getMetadata() {
+        return metadata;
+    }
+
+    public String getValue(Cli cli) {
+        return Objects.requireNonNull(cli, "cli").optionString(metadata.getName());
+    }
+
+    public Collection<String> getValues(Cli cli) {
+        return Objects.requireNonNull(cli, "cli").optionStrings(metadata.getName());
+    }
+
+    public static class Builder {
+
+        private final OptionMetadata.Builder delegate;
+
+        public Builder(String name) {
+            this.delegate = OptionMetadata.builder(name);
+            this.delegate.valueRequired();
+        }
+
+        public Builder description(String description) {
+            delegate.description(description);
+            return this;
+        }
+
+        public Builder shortName(char shortName) {
+            delegate.shortName(shortName);
+            return this;
+        }
+
+        public Builder shortName(String shortName) {
+            delegate.shortName(shortName);
+            return this;
+        }
+
+        public Builder valueRequired() {
+            delegate.valueRequired();
+            return this;
+        }
+
+        public Builder valueRequired(String valueName) {
+            delegate.valueRequired(valueName);
+            return this;
+        }
+
+        public Builder valueOptional() {
+            delegate.valueOptional();
+            return this;
+        }
+
+        public Builder valueOptional(String valueName) {
+            delegate.valueOptional(valueName);
+            return this;
+        }
+
+        public Builder valueOptionalWithDefault(String defaultValue) {
+            delegate.valueOptionalWithDefault(defaultValue);
+            return this;
+        }
+
+        public Builder valueOptionalWithDefault(String valueName, String defaultValue) {
+            delegate.valueOptionalWithDefault(valueName, defaultValue);
+            return this;
+        }
+
+        public ValueOption build() {
+            return new ValueOption(delegate.build());
+        }
+    }
+}

--- a/bootique/src/test/java/io/bootique/OptionApiIT.java
+++ b/bootique/src/test/java/io/bootique/OptionApiIT.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to ObjectStyle LLC under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ObjectStyle LLC licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.bootique;
+
+import io.bootique.cli.Cli;
+import io.bootique.config.ConfigurationFactory;
+import io.bootique.option.ConfigResourceOption;
+import io.bootique.option.ConfigValueOption;
+import io.bootique.option.FlagOption;
+import io.bootique.option.Option;
+import io.bootique.option.ValueOption;
+import io.bootique.unit.TestAppManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OptionApiIT {
+
+    @RegisterExtension
+    final TestAppManager appManager = new TestAppManager();
+
+    @Test
+    public void flagAndValueOptions_ExposeMetadataAndCliHelpers() {
+        FlagOption flag = Option.flag("switch")
+                .description("A boolean switch")
+                .shortName('s')
+                .build();
+
+        ValueOption value = Option.valueOption("value")
+                .description("A required value")
+                .shortName('v')
+                .build();
+
+        BQRuntime runtime = appManager.runtime(Bootique.app("-s", "--value=abc")
+                .module(b -> BQCoreModule.extend(b).addOptions(flag, value)));
+
+        Cli cli = runtime.getInstance(Cli.class);
+
+        assertTrue(flag.isSet(cli));
+        assertTrue(value.isSet(cli));
+        assertEquals("abc", value.getValue(cli));
+    }
+
+    @Test
+    public void configValueOption_BindsConfigPath() {
+        ConfigValueOption option = Option.configValue("opt-1", "c.m.f")
+                .description("Maps an option to config")
+                .build();
+
+        BQRuntime runtime = appManager.runtime(Bootique.app("--config=classpath:io/bootique/config/test4.yml", "--opt-1=x")
+                .module(b -> BQCoreModule.extend(b).addOption(option)));
+
+        Bean1 bean1 = runtime.getInstance(ConfigurationFactory.class).config(Bean1.class, "");
+
+        assertEquals("x", bean1.c.m.f);
+    }
+
+    @Test
+    public void configResourceOption_BindsConfigResource() {
+        ConfigResourceOption option = Option.configResource("file-opt-1", "classpath:io/bootique/config/configTest4Opt1.yml")
+                .build();
+
+        BQRuntime runtime = appManager.runtime(Bootique.app("--config=classpath:io/bootique/config/test4.yml", "--file-opt-1")
+                .module(b -> BQCoreModule.extend(b).addOption(option)));
+
+        Bean1 bean1 = runtime.getInstance(ConfigurationFactory.class).config(Bean1.class, "");
+
+        assertEquals("f", bean1.c.m.f);
+        assertEquals(1, bean1.c.m.k);
+    }
+
+    private record Bean1(String a, Bean2 c) {}
+
+    private record Bean2(Bean3 m) {}
+
+    private record Bean3(String f, int k) {}
+}

--- a/bootique/src/test/java/io/bootique/option/OptionApiTest.java
+++ b/bootique/src/test/java/io/bootique/option/OptionApiTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to ObjectStyle LLC under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ObjectStyle LLC licenses
+ * this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.bootique.option;
+
+import io.bootique.meta.application.CommandMetadata;
+import io.bootique.meta.application.OptionMetadata;
+import io.bootique.meta.application.OptionValueCardinality;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OptionApiTest {
+
+    @Test
+    public void flagAndValueOptions_ExposeMetadata() {
+        FlagOption flag = Option.flag("switch")
+                .description("A boolean switch")
+                .shortName('s')
+                .build();
+
+        ValueOption value = Option.valueOption("value")
+                .description("A required value")
+                .shortName('v')
+                .build();
+
+        assertEquals("switch", flag.getMetadata().getName());
+        assertEquals("value", value.getMetadata().getName());
+        assertEquals(OptionValueCardinality.NONE, flag.getMetadata().getValueCardinality());
+        assertEquals(OptionValueCardinality.REQUIRED, value.getMetadata().getValueCardinality());
+    }
+
+    @Test
+    public void configOptions_ExposeConfigBindings() {
+        ConfigValueOption configValue = Option.configValue("opt-1", "c.m.f").build();
+        ConfigResourceOption configResource = Option.configResource("file-opt-1", "classpath:io/bootique/config/configTest4Opt1.yml")
+                .build();
+
+        assertEquals("c.m.f", configValue.getConfigPath());
+        assertEquals("classpath:io/bootique/config/configTest4Opt1.yml", configResource.getConfigResourceId());
+    }
+
+    @Test
+    public void configValueOption_RejectsNullConfigPath() {
+        assertThrows(NullPointerException.class, () -> Option.configValue("opt-1", null));
+    }
+
+    @Test
+    public void configResourceOption_RejectsNullConfigResourceId() {
+        assertThrows(NullPointerException.class, () -> Option.configResource("file-opt-1", null));
+    }
+
+    @Test
+    public void commandMetadata_AcceptsOptionObjects() {
+        CommandMetadata metadata = CommandMetadata.builder("sample")
+                .addOption(Option.flag("switch").build())
+                .addOption(Option.valueOption("value").build())
+                .build();
+
+        assertEquals("sample", metadata.getName());
+        assertEquals(2, metadata.getOptions().size());
+        assertTrue(metadata.getOptions().stream().map(OptionMetadata::getName).anyMatch("switch"::equals));
+        assertTrue(metadata.getOptions().stream().map(OptionMetadata::getName).anyMatch("value"::equals));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Introduces a semantic CLI `Option` API that wraps existing option metadata while preserving backward compatibility.

## Details

Adds typed option abstractions for flags, value options, config value bindings, and config resource bindings. Existing metadata-based APIs remain supported, with overloads added so new option objects can be used incrementally without changing existing callers.

## Testing

Added separate unit and integration coverage for option metadata, CLI helpers, command metadata support, and config binding behavior.